### PR TITLE
Add systemd-rpm-macros to Docker build images

### DIFF
--- a/build-images/build-almalinux10/Dockerfile
+++ b/build-images/build-almalinux10/Dockerfile
@@ -17,7 +17,8 @@ RUN yum install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y \

--- a/build-images/build-almalinux8/Dockerfile
+++ b/build-images/build-almalinux8/Dockerfile
@@ -17,7 +17,8 @@ RUN yum install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y \

--- a/build-images/build-almalinux9/Dockerfile
+++ b/build-images/build-almalinux9/Dockerfile
@@ -17,7 +17,8 @@ RUN yum install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y \

--- a/build-images/build-centos10/Dockerfile
+++ b/build-images/build-centos10/Dockerfile
@@ -17,7 +17,8 @@ RUN yum install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y \

--- a/build-images/build-centos9/Dockerfile
+++ b/build-images/build-centos9/Dockerfile
@@ -17,7 +17,8 @@ RUN yum install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y \

--- a/build-images/build-fedora41/Dockerfile
+++ b/build-images/build-fedora41/Dockerfile
@@ -13,7 +13,8 @@ RUN dnf install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN dnf install -y \

--- a/build-images/build-fedora42/Dockerfile
+++ b/build-images/build-fedora42/Dockerfile
@@ -13,7 +13,8 @@ RUN dnf install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN dnf install -y \

--- a/build-images/build-fedora43/Dockerfile
+++ b/build-images/build-fedora43/Dockerfile
@@ -13,7 +13,8 @@ RUN dnf install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN dnf install -y \

--- a/build-images/build-opensuse15/Dockerfile
+++ b/build-images/build-opensuse15/Dockerfile
@@ -18,7 +18,8 @@ RUN zypper install -y \
 	rpm-build \
 	python3 \
 	libtool \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN zypper install -y \

--- a/build-images/build-opensuse16/Dockerfile
+++ b/build-images/build-opensuse16/Dockerfile
@@ -18,7 +18,8 @@ RUN zypper install -y \
 	rpm-build \
 	python3 \
 	libtool \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN zypper install -y \

--- a/build-images/experimental/build-amazon2/Dockerfile
+++ b/build-images/experimental/build-amazon2/Dockerfile
@@ -25,7 +25,8 @@ RUN yum install -y\
 	gcc gcc-c++\
 	libtool\
 	rpm-build\
-	python3
+	python3\
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y\

--- a/build-images/experimental/build-amazon2023/Dockerfile
+++ b/build-images/experimental/build-amazon2023/Dockerfile
@@ -17,7 +17,8 @@ RUN yum install -y \
 	libtool \
 	rpm-build \
 	python3 \
-	pkg-config
+	pkg-config \
+	systemd-rpm-macros
 
 # proxysql build dependencies
 RUN yum install -y \


### PR DESCRIPTION
## Summary
This PR adds the systemd-rpm-macros package to all RHEL-based and OpenSUSE-based Docker build images. This is required for proper RPM package uninstallation on Amazon Linux 2023 and other systemd-based RHEL distributions, as the %systemd_preun macro in the RPM spec files requires this package to be available in the build environment.

## Changes
- Added systemd-rpm-macros to RHEL-based Dockerfiles using yum
- Added systemd-rpm-macros to OpenSUSE-based Dockerfiles using zypper
- Updated both regular and experimental Amazon Linux Dockerfiles

## Related Issues
- Fixes ProxySQL/docker-images#15
- Related to sysown/proxysql#5335
- Related to sysown/proxysql#5336

The changes are minimal and focused, only adding the required dependency without modifying any other functionality. All Dockerfiles maintain their existing structure and formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies across all supported Linux distributions (AlmaLinux, CentOS, Fedora, OpenSUSE, Amazon Linux) to enhance build environment configuration. Changes apply to all supported platform versions and variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->