### PR TITLE
add rpm-macros

### DIFF
--- a/build-clang-images/build-clang-almalinux10/Dockerfile
+++ b/build-clang-images/build-clang-almalinux10/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	libuuid-devel \
 	zlib-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN yum clean all && \

--- a/build-clang-images/build-clang-almalinux8/Dockerfile
+++ b/build-clang-images/build-clang-almalinux8/Dockerfile
@@ -32,7 +32,8 @@ RUN yum install -y \
 	perl-IPC-Cmd \
 	libuuid-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN yum clean all && \

--- a/build-clang-images/build-clang-almalinux9/Dockerfile
+++ b/build-clang-images/build-clang-almalinux9/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	libuuid-devel \
 	zlib-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN yum clean all && \

--- a/build-clang-images/build-clang-centos10/Dockerfile
+++ b/build-clang-images/build-clang-centos10/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	libuuid-devel \
 	zlib-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN yum clean all && \

--- a/build-clang-images/build-clang-centos9/Dockerfile
+++ b/build-clang-images/build-clang-centos9/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	libuuid-devel \
 	zlib-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN yum clean all && \

--- a/build-clang-images/build-clang-fedora42/Dockerfile
+++ b/build-clang-images/build-clang-fedora42/Dockerfile
@@ -28,7 +28,8 @@ RUN dnf install -y \
 	perl-IPC-Cmd \
 	libuuid-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN dnf clean all && \

--- a/build-clang-images/build-clang-fedora43/Dockerfile
+++ b/build-clang-images/build-clang-fedora43/Dockerfile
@@ -28,7 +28,8 @@ RUN dnf install -y \
 	perl-IPC-Cmd \
 	libuuid-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN dnf clean all && \

--- a/build-clang-images/build-clang-opensuse15/Dockerfile
+++ b/build-clang-images/build-clang-opensuse15/Dockerfile
@@ -26,7 +26,8 @@ RUN zypper install -y \
 	libc++-devel libstdc++-devel \
 	libuuid-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 RUN zypper addrepo -f 'http://download.opensuse.org/distribution/leap/15.6/repo/oss/' leap-15.6-oss
 RUN zypper install -y \

--- a/build-clang-images/build-clang-opensuse16/Dockerfile
+++ b/build-clang-images/build-clang-opensuse16/Dockerfile
@@ -28,7 +28,8 @@ RUN zypper install -y \
 	libc++-devel libstdc++-devel \
 	libuuid-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 #RUN zypper addrepo -f 'http://download.opensuse.org/tumbleweed/repo/oss/' tumbleweed-oss
 RUN zypper addrepo -f 'http://download.opensuse.org/distribution/leap/16.0/repo/oss/' leap-16.0-oss

--- a/build-clang-images/obsolete/build-clang-fedora41/Dockerfile
+++ b/build-clang-images/obsolete/build-clang-fedora41/Dockerfile
@@ -28,7 +28,8 @@ RUN dnf install -y \
 	perl-IPC-Cmd \
 	libuuid-devel \
 	libicu-devel \
-	libevent-devel
+	libevent-devel \
+	systemd-rpm-macros
 
 # cleanup rpm cache
 RUN dnf clean all && \

--- a/build-images/build-almalinux10/Dockerfile
+++ b/build-images/build-almalinux10/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	zlib-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo
 RUN yum install -y --enablerepo=crb \

--- a/build-images/build-almalinux8/Dockerfile
+++ b/build-images/build-almalinux8/Dockerfile
@@ -30,7 +30,8 @@ RUN yum install -y \
 	libuuid-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo
 RUN yum install -y --enablerepo=powertools \

--- a/build-images/build-almalinux9/Dockerfile
+++ b/build-images/build-almalinux9/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	zlib-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo
 RUN yum install -y --enablerepo=crb \

--- a/build-images/build-centos10/Dockerfile
+++ b/build-images/build-centos10/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	zlib-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo
 RUN yum install -y --enablerepo=crb \

--- a/build-images/build-centos9/Dockerfile
+++ b/build-images/build-centos9/Dockerfile
@@ -31,7 +31,8 @@ RUN yum install -y \
 	zlib-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo
 RUN yum install -y --enablerepo=crb \

--- a/build-images/build-fedora42/Dockerfile
+++ b/build-images/build-fedora42/Dockerfile
@@ -27,7 +27,8 @@ RUN dnf install -y \
 	libuuid-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo on CentOS
 RUN yum install -y \

--- a/build-images/build-fedora43/Dockerfile
+++ b/build-images/build-fedora43/Dockerfile
@@ -27,7 +27,8 @@ RUN dnf install -y \
 	libuuid-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo on CentOS
 RUN yum install -y \

--- a/build-images/build-opensuse15/Dockerfile
+++ b/build-images/build-opensuse15/Dockerfile
@@ -29,7 +29,8 @@ RUN zypper install -y \
 	libuuid-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 RUN zypper addrepo -f 'http://download.opensuse.org/distribution/leap/15.6/repo/oss/' leap-15.6-oss
 RUN zypper install -y \

--- a/build-images/build-opensuse16/Dockerfile
+++ b/build-images/build-opensuse16/Dockerfile
@@ -28,7 +28,8 @@ RUN zypper install -y \
 	libuuid-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 #RUN zypper addrepo -f 'http://download.opensuse.org/tumbleweed/repo/oss/' tumbleweed-oss
 RUN zypper addrepo -f 'http://download.opensuse.org/distribution/leap/16.0/repo/oss/' leap-16.0-oss

--- a/build-images/obsolete/build-fedora41/Dockerfile
+++ b/build-images/obsolete/build-fedora41/Dockerfile
@@ -27,7 +27,8 @@ RUN dnf install -y \
 	libuuid-devel \
 	libicu-devel \
 	libevent-devel \
-	ncurses-devel
+	ncurses-devel \
+	systemd-rpm-macros
 
 # install from CRB repo on CentOS
 RUN yum install -y \


### PR DESCRIPTION
update build images with new package `systemd-rpm-macros`

remove obsolete fedora41 builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `systemd-rpm-macros` package to build dependencies across multiple container images (AlmaLinux 8/9/10, CentOS 9/10, Fedora 41/42/43, and OpenSUSE 15/16) to support systemd macro functionality in build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->