### PR TITLE
add fedora44

### DIFF
--- a/build-clang-images/build-clang-fedora44/Dockerfile
+++ b/build-clang-images/build-clang-fedora44/Dockerfile
@@ -1,0 +1,51 @@
+FROM fedora:44
+LABEL authors="Miro Stauder <miro@sysown.com>"
+
+# update packages
+RUN dnf update -y
+
+# clang & build tools
+RUN dnf install -y \
+	make cmake automake bison flex \
+	git patch which \
+	bzip2 tar wget
+
+# try avoiding pulling gcc as dependency
+RUN dnf install -y --setopt=install_weak_deps=False --best \
+	clang lld compiler-rt \
+	rpm-build \
+	python3 \
+	libtool \
+	pkg-config
+
+# proxysql build dependencies
+RUN dnf install -y \
+	openssl openssl-devel openssl-devel-engine \
+	gnutls gnutls-devel \
+	libunwind libunwind-devel \
+	zlib-devel \
+	perl-FindBin \
+	perl-IPC-Cmd \
+	libuuid-devel \
+	libicu-devel \
+	libevent-devel \
+	systemd-rpm-macros
+
+# cleanup rpm cache
+RUN dnf clean all && \
+	rm -rf /var/cache/yum
+
+# configure git safe dir
+RUN git config --global --add safe.directory '*'
+
+ENV CC=clang
+ENV CXX=clang++
+
+RUN ${CXX} --version
+
+# build && install current cmake
+#RUN cd /root && wget --no-check-certificate https://cmake.org/files/v3.22/cmake-3.22.1.tar.gz && tar -zxf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./configure && gmake -j$(nproc) && gmake install && cd .. && rm -rf cmake-3.22.1.tar.gz cmake-3.22.1
+# better version alredy provided
+
+# remove gcc pulled in as clang dependency
+#RUN rpm -e --nodeps gcc gcc-c++

--- a/build-images/build-fedora44/Dockerfile
+++ b/build-images/build-fedora44/Dockerfile
@@ -1,0 +1,52 @@
+FROM fedora:44
+LABEL authors="Miro Stauder <miro@sysown.com>"
+
+# update packages
+RUN dnf update -y
+
+# gcc & build tools
+RUN dnf install -y \
+	make cmake automake bison flex \
+	git patch \
+	bzip2 tar wget \
+	gcc gcc-c++ \
+	libtool \
+	rpm-build \
+	python3 \
+	pkg-config
+
+# proxysql build dependencies
+RUN dnf install -y \
+	openssl openssl-devel openssl-devel-engine \
+	gnutls gnutls-devel \
+	libunwind libunwind-devel \
+	zlib-devel \
+	perl-FindBin \
+	perl-IPC-Cmd \
+	perl-Time-Piece \
+	libuuid-devel \
+	libicu-devel \
+	libevent-devel \
+	ncurses-devel \
+	systemd-rpm-macros
+
+# install from CRB repo on CentOS
+RUN yum install -y \
+	libtirpc-devel \
+	rpcgen
+
+# debug images need valgrind
+RUN dnf install -y \
+	valgrind valgrind-devel
+
+# cleanup rpm cache
+RUN dnf clean all && \
+	rm -rf /var/cache/yum
+
+# configure git safe dir
+RUN git config --global --add safe.directory '*'
+
+ENV CC=gcc
+ENV CXX=g++
+
+RUN ${CXX} --version


### PR DESCRIPTION
## Summary

- Adds `build-images/build-fedora44/Dockerfile` and `build-clang-images/build-clang-fedora44/Dockerfile`.
- Identical to the fedora43 Dockerfiles except for the base image (`FROM fedora:43` → `FROM fedora:44`).
- Fedora 44 ships **GCC 16.1.1** by default (verified in `fedora:44` and `fedora:rawhide`), so once these images are published as `proxysql/packaging:build-fedora44-v4.0.0` and `proxysql/packaging:build-clang-fedora44-v4.0.0`, the matching fedora44 entry in [sysown/proxysql](https://github.com/sysown/proxysql)'s build matrix will exercise GCC 16 on every PR.

This is the docker-images side of the fix for [sysown/proxysql#5770](https://github.com/sysown/proxysql/issues/5770) (jemalloc fails to build on GCC 16).

## Build & push

```bash
cd build-images       && PUSH=1 make build-fedora44
cd build-clang-images && PUSH=1 make build-clang-fedora44
```

## Test plan

- [ ] `docker buildx build` succeeds for `build-fedora44` on amd64
- [ ] `docker buildx build` succeeds for `build-fedora44` on arm64
- [ ] `docker buildx build` succeeds for `build-clang-fedora44` on amd64
- [ ] `docker buildx build` succeeds for `build-clang-fedora44` on arm64
- [ ] Images pushed to Docker Hub with both unversioned and `-v4.0.0` tags
- [ ] sysown/proxysql fedora44 packaging workflows succeed against the published images