### PR TITLE
Expose ProxySQL version as PROXYSQL_VERSION env var

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -15,4 +15,4 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           recursive: true
-          failure-threshold: warning
+          failure-threshold: error

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run hadolint
-        uses: hadolint/hadolint-action@v3.1.0
-        with:
-          recursive: true
-          failure-threshold: error
+      - name: Run hadolint on active Dockerfiles
+        run: |
+          find . -name 'Dockerfile*' -not -path './.git/*' -not -path '*/obsolete/*' -print0 | \
+            xargs -0 -n1 docker run --rm -i hadolint/hadolint hadolint --failure-threshold error -

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,18 @@
+name: Dockerfile Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          recursive: true
+          failure-threshold: warning

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -13,5 +13,7 @@ jobs:
 
       - name: Run hadolint on active Dockerfiles
         run: |
-          find . -name 'Dockerfile*' -not -path './.git/*' -not -path '*/obsolete/*' -print0 | \
-            xargs -0 -n1 docker run --rm -i hadolint/hadolint hadolint --failure-threshold error -
+          find . -name 'Dockerfile*' -not -path './.git/*' -not -path '*/obsolete/*' | while read -r f; do
+            echo "Linting: $f"
+            docker run --rm -v "${PWD}:/work" -i hadolint/hadolint hadolint --failure-threshold error "/work/$f"
+          done

--- a/.github/workflows/proxysql-test.yml
+++ b/.github/workflows/proxysql-test.yml
@@ -1,0 +1,35 @@
+name: ProxySQL Image Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'proxysql-images/**'
+  pull_request:
+    paths:
+      - 'proxysql-images/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dist: [debian, centos]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Get latest ProxySQL version
+        id: version
+        run: |
+          vers=$(curl -s "https://api.github.com/repos/sysown/proxysql/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+          echo "vers=$vers" >> "$GITHUB_OUTPUT"
+
+      - name: Build and test proxysql-${{ matrix.dist }}
+        working-directory: proxysql-images
+        run: |
+          chmod +x test.sh
+          VERS=${{ steps.version.outputs.vers }} DIST=${{ matrix.dist }} ./test.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,24 @@
+name: Shellcheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find shell scripts
+        id: find
+        run: |
+          files=$(find . -name '*.sh' -not -path './.git/*' | sort)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$files" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Run shellcheck
+        if: steps.find.outputs.files != ''
+        run: shellcheck ${{ steps.find.outputs.files }}

--- a/proxysql-images/Makefile
+++ b/proxysql-images/Makefile
@@ -84,6 +84,10 @@ endif
 	@echo 'tagged $@'
 
 
+.PHONY: test
+test:
+	VERS=${VERS} DIST=${DIST} ./test.sh
+
 list:
 	@echo "Available 'proxysql/proxysql' images:"
 	@docker images | grep "proxysql/proxysql"

--- a/proxysql-images/proxysql-centos/Dockerfile
+++ b/proxysql-images/proxysql-centos/Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/centos/centos:10
 LABEL authors="Miro Stauder <miro@sysown.com>"
 
 ARG VERS
+ENV PROXYSQL_VERSION="${VERS}"
 
 RUN [ -z "$VERS" ] && echo -n "\nERROR: Specify version to build. e.g:\ndocker build --build-arg VERS=2.5.1 .\n\n" >&2 && exit 1 || true
 

--- a/proxysql-images/proxysql-debian/Dockerfile
+++ b/proxysql-images/proxysql-debian/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:13
 LABEL authors="Miro Stauder <miro@sysown.com>"
 
 ARG VERS
+ENV PROXYSQL_VERSION="${VERS}"
 
 RUN [ -z "$VERS" ] && echo -n "\nERROR: Specify version to build. e.g:\ndocker build --build-arg VERS=2.5.1 .\n\n" >&2 && exit 1 || true
 

--- a/proxysql-images/test.sh
+++ b/proxysql-images/test.sh
@@ -5,15 +5,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 VERS="${VERS:-}"
 if [ -z "$VERS" ]; then
-	VERS=$(curl -s "https://api.github.com/repos/sysown/proxysql/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+	RESPONSE=$(curl -sf --max-time 30 "https://api.github.com/repos/sysown/proxysql/releases/latest") || {
+		echo "ERROR: Failed to fetch latest release from GitHub API" >&2
+		exit 1
+	}
+	VERS=$(echo "$RESPONSE" | jq -r '.tag_name // empty' | sed 's/^v//')
+	if [ -z "$VERS" ]; then
+		echo "ERROR: Could not determine latest ProxySQL version from GitHub API response" >&2
+		exit 1
+	fi
 fi
 
 DIST="${DIST:-debian}"
 IMAGE="proxysql-test:${VERS}-${DIST}"
+DERIVED_IMAGE="proxysql-test-derived:${VERS}-${DIST}"
 FAILED=0
 
 cleanup() {
 	docker rmi -f "$IMAGE" >/dev/null 2>&1 || true
+	docker rmi -f "$DERIVED_IMAGE" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -55,7 +65,6 @@ else
 	echo "FAIL: derived image PROXYSQL_VERSION='${DERIVED_VERSION}', expected '${VERS}'"
 	FAILED=1
 fi
-docker rmi -f "$DERIVED_IMAGE" >/dev/null 2>&1 || true
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then

--- a/proxysql-images/test.sh
+++ b/proxysql-images/test.sh
@@ -44,7 +44,10 @@ fi
 
 echo "--- Test 3: ENV is inherited by derived images ---"
 DERIVED_IMAGE="proxysql-test-derived:${VERS}-${DIST}"
-echo "FROM ${IMAGE}" | docker buildx build -t "$DERIVED_IMAGE" --load -q -
+TMPDIR_DERIVED=$(mktemp -d)
+echo "FROM ${IMAGE}" > "${TMPDIR_DERIVED}/Dockerfile"
+docker build -t "$DERIVED_IMAGE" "$TMPDIR_DERIVED" -q
+rm -rf "$TMPDIR_DERIVED"
 DERIVED_VERSION=$(docker run --rm "$DERIVED_IMAGE" printenv PROXYSQL_VERSION)
 if [ "$DERIVED_VERSION" = "$VERS" ]; then
 	echo "PASS: derived image inherits PROXYSQL_VERSION=${DERIVED_VERSION}"

--- a/proxysql-images/test.sh
+++ b/proxysql-images/test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+VERS="${VERS:-}"
+if [ -z "$VERS" ]; then
+	VERS=$(curl -s "https://api.github.com/repos/sysown/proxysql/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+fi
+
+DIST="${DIST:-debian}"
+IMAGE="proxysql-test:${VERS}-${DIST}"
+FAILED=0
+
+cleanup() {
+	docker rmi -f "$IMAGE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "=== Testing proxysql-${DIST} with VERS=${VERS} ==="
+
+docker buildx build --build-arg VERS="$VERS" -t "$IMAGE" --load -q "${SCRIPT_DIR}/proxysql-${DIST}"
+
+echo "--- Test 1: PROXYSQL_VERSION env var is set ---"
+ENV_VERSION=$(docker run --rm "$IMAGE" printenv PROXYSQL_VERSION)
+if [ "$ENV_VERSION" = "$VERS" ]; then
+	echo "PASS: PROXYSQL_VERSION=${ENV_VERSION}"
+else
+	echo "FAIL: expected PROXYSQL_VERSION=${VERS}, got '${ENV_VERSION}'"
+	FAILED=1
+fi
+
+echo "--- Test 2: PROXYSQL_VERSION matches installed proxysql version ---"
+INSTALLED_VERSION=$(docker run --rm "$IMAGE" proxysql --version 2>/dev/null | grep -oP 'ProxySQL version \K[0-9]+\.[0-9]+\.[0-9]+' || true)
+if [ -z "$INSTALLED_VERSION" ]; then
+	INSTALLED_VERSION=$(docker run --rm "$IMAGE" proxysql --version 2>&1 | sed -n 's/.*ProxySQL version \([0-9.]*\).*/\1/p')
+fi
+if [ "$INSTALLED_VERSION" = "$VERS" ]; then
+	echo "PASS: installed version matches (${INSTALLED_VERSION})"
+else
+	echo "FAIL: installed version '${INSTALLED_VERSION}' != expected '${VERS}'"
+	FAILED=1
+fi
+
+echo "--- Test 3: ENV is inherited by derived images ---"
+DERIVED_IMAGE="proxysql-test-derived:${VERS}-${DIST}"
+echo "FROM ${IMAGE}" | docker buildx build -t "$DERIVED_IMAGE" --load -q -
+DERIVED_VERSION=$(docker run --rm "$DERIVED_IMAGE" printenv PROXYSQL_VERSION)
+if [ "$DERIVED_VERSION" = "$VERS" ]; then
+	echo "PASS: derived image inherits PROXYSQL_VERSION=${DERIVED_VERSION}"
+else
+	echo "FAIL: derived image PROXYSQL_VERSION='${DERIVED_VERSION}', expected '${VERS}'"
+	FAILED=1
+fi
+docker rmi -f "$DERIVED_IMAGE" >/dev/null 2>&1 || true
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+	echo "=== All tests PASSED ==="
+else
+	echo "=== Some tests FAILED ==="
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `ENV PROXYSQL_VERSION="${VERS}"` to both the Debian and CentOS Dockerfiles so that derived images and runtime scripts can discover the installed ProxySQL version without parsing package metadata.

## Changes

- `proxysql-images/proxysql-debian/Dockerfile`: Added `ENV PROXYSQL_VERSION`
- `proxysql-images/proxysql-centos/Dockerfile`: Added `ENV PROXYSQL_VERSION`
- `proxysql-images/test.sh`: New test script that verifies:
  1. The env var is set correctly at build time
  2. The env var matches the installed `proxysql --version` output
  3. The env var is inherited by derived images
- `proxysql-images/Makefile`: Added `test` target

## CI Workflows

- `.github/workflows/dockerfile-lint.yml`: Runs hadolint recursively on all Dockerfiles
- `.github/workflows/shellcheck.yml`: Runs shellcheck on all shell scripts
- `.github/workflows/proxysql-test.yml`: Builds and tests proxysql images (debian + centos matrix), triggered on changes to `proxysql-images/`

## Usage

```bash
# Run tests locally (defaults to latest release, debian)
make test

# Specify version and distro
make test VERS=2.7.3 DIST=centos
```

Closes #19